### PR TITLE
Tweak to setup.py to allow setuptools development mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(name='pyNLO',
                 'pynlo.media.fibers',
                 'pynlo.util',
                 'pynlo.util.ode_solve'],
-      package_dir = {'pynlo': 'src/pynlo'},
+      package_dir = {'': 'src'},
       package_data = {'pynlo': ['media/fibers/*.txt']},
      )


### PR DESCRIPTION
This is needed to allow `python setup.py develop` to work. 

`python setup.py install` should be unaffected.