### PR TITLE
Added function to PulseBase to calculate spectrogram

### DIFF
--- a/src/pynlo/interactions/FourWaveMixing/global_variables.py
+++ b/src/pynlo/interactions/FourWaveMixing/global_variables.py
@@ -21,7 +21,7 @@ This file is part of pyNLO.
 ###     Global variables    ###
 #   USE_PYFFTW : True   - > use pyfftw
 #                False  - > use numpy fft
-USE_PYFFTW = True
+USE_PYFFTW = False
 #   USE_FREQUENCY_DOMAIN_RAMAN : 
 #   True   - > calculate Raman respose in frequency domain (older)
 #   False  - > calculate Raman reponse in time domain (Modern version)

--- a/src/pynlo/media/fibers/fiber.py
+++ b/src/pynlo/media/fibers/fiber.py
@@ -80,7 +80,7 @@ class FiberInstance:
         if fiberName == None:
             self.fibertype = os.path.basename(filename)
         else:
-            self.sibertype = fiberName
+            self.fibertype = fiberName
         
         self.fiberspecs["dispersion_format"] = "D"
         self.poly_order = poly_order


### PR DESCRIPTION
[Dudley](http://journals.aps.org/rmp/abstract/10.1103/RevModPhys.78.1135) makes a big deal about calculating the spectrogram of the pulse (for example, see his Fig. 10). I included a function in PulseBase to allow the spectrogram to be calculated.

The results look something like this (pulse after propagation in a nonlinear fiber):

![figure_4](https://cloud.githubusercontent.com/assets/1107796/13677997/aed06efe-e6a9-11e5-9e6c-75f0cefeea19.png)

Note: this PR should be merged after (or in place of) https://github.com/ycasg/PyNLO/pull/14.